### PR TITLE
Add "automatic" help command that generates the embed from loaded cogs.

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from moosebot import MooseBot
 from moosebot.cogs import *
 
 with open('database/token.txt') as f:
-    token = f.readline()
+    token = f.readline().strip()
 
 moose = MooseBot(token)
 admins = ["192519529417408512", "536170543859105794"]

--- a/moosebot/__init__.py
+++ b/moosebot/__init__.py
@@ -1,5 +1,6 @@
 from moosebot.bot import MooseBot
 from moosebot.database import MooseDb
+from moosebot.cog_helper import *
 
 __all__ = [
     "cogs",
@@ -7,5 +8,7 @@ __all__ = [
     "bot",
     "MooseBot",
     "MooseDb",
-    "utils"
+    "utils",
+    "cog_group",
+    "get_cog_group"
 ]

--- a/moosebot/cog_helper.py
+++ b/moosebot/cog_helper.py
@@ -1,0 +1,27 @@
+from typing import Type
+
+from discord.ext.commands import Bot
+
+overrides = {}
+
+
+def cog_group(name: str):
+    """
+    Utility decorator for setting the desired display text for a cog in the help command.
+    :param name: the desired cog name
+    :return: a function that accepts a type and sets its cog name override to the provided string.
+    """
+    def inner(cls: Type):
+        overrides[cls] = name
+        return cls
+
+    return inner
+
+
+def get_cog_group(client: Bot, cog: str):
+    """
+    :param client: the Discord client instance
+    :param cog: the cog's name, as registered in the client
+    :return: the cog's display name, or its default name if it has not been overridden
+    """
+    return overrides.get(type(client.get_cog(cog)), cog)

--- a/moosebot/cogs/__init__.py
+++ b/moosebot/cogs/__init__.py
@@ -6,7 +6,6 @@ from moosebot.cogs.experience import Experience
 from moosebot.cogs.fun import Fun
 from moosebot.cogs.guess_game import GuessGame
 from moosebot.cogs.images import Images
-from moosebot.cogs.info import Info
 from moosebot.cogs.misc import Misc
 from moosebot.cogs.moderation import Moderation
 from moosebot.cogs.numbers import Numbers
@@ -16,6 +15,9 @@ from moosebot.cogs.server import Server
 from moosebot.cogs.shop import Shop
 from moosebot.cogs.voice import Voice
 from moosebot.cogs.fishing import Fishing
+
+# Import this last so other cog types are importable for help purposes
+from moosebot.cogs.info import Info
 
 __all__ = [
     "Info",

--- a/moosebot/cogs/colour.py
+++ b/moosebot/cogs/colour.py
@@ -2,9 +2,10 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import Cog
 
-from moosebot import MooseBot
+from moosebot import MooseBot, cog_group
 
 
+@cog_group("Fun")
 class Colour(Cog):
 
     def __init__(self, bot: MooseBot):

--- a/moosebot/cogs/counting.py
+++ b/moosebot/cogs/counting.py
@@ -1,9 +1,10 @@
 from discord.ext import commands
 from discord.ext.commands import Cog
 
-from moosebot import MooseBot
+from moosebot import MooseBot, cog_group
 
 
+@cog_group("Interactive")
 class Counting(Cog):
 
     def __init__(self, bot: MooseBot):

--- a/moosebot/cogs/fishing.py
+++ b/moosebot/cogs/fishing.py
@@ -5,9 +5,10 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import Cog
 
-from moosebot import MooseBot, converters
+from moosebot import MooseBot, converters, cog_group
 
 
+@cog_group("Economy")
 class Fishing(Cog):
 
     def __init__(self, bot: MooseBot):

--- a/moosebot/cogs/fun.py
+++ b/moosebot/cogs/fun.py
@@ -535,7 +535,8 @@ class Fun(Cog):
         await ctx.send(f"💜`{arg1}`\n💜`{arg2}`")
         await ctx.send(embed=embed)
 
-    @commands.command(aliases=["eightball", "8", "ball", "8ball"],
+    @commands.command(name="8ball",
+                      aliases=["eightball", "8", "ball"],
                       help="Simple 8ball, ask a yes/no question and I'll tell "
                            "you the outcome. \n`>8ball question`")
     async def eight_ball(self, ctx):

--- a/moosebot/cogs/guess_game.py
+++ b/moosebot/cogs/guess_game.py
@@ -3,10 +3,11 @@ import random
 from discord.ext import commands
 from discord.ext.commands import Cog
 
-from moosebot import MooseBot
+from moosebot import MooseBot, cog_group
 
 
-class GuessGame(Cog):
+@cog_group("Interactive")
+class GuessGame(Cog, name="Guessing Game"):
 
     def __init__(self, bot: MooseBot):
         self.bot = bot

--- a/moosebot/cogs/numbers.py
+++ b/moosebot/cogs/numbers.py
@@ -2,9 +2,10 @@ import requests
 from discord.ext import commands
 from discord.ext.commands import Cog
 
-from moosebot import MooseBot
+from moosebot import MooseBot, cog_group
 
 
+@cog_group("Misc")
 class Numbers(Cog):
 
     def __init__(self, bot: MooseBot):

--- a/moosebot/cogs/phone.py
+++ b/moosebot/cogs/phone.py
@@ -1,9 +1,10 @@
 from discord.ext import commands
 from discord.ext.commands import Cog
 
-from moosebot import MooseBot
+from moosebot import MooseBot, cog_group
 
 
+@cog_group("Interactive")
 class Phone(Cog):
 
     def __init__(self, bot: MooseBot):

--- a/moosebot/cogs/server.py
+++ b/moosebot/cogs/server.py
@@ -2,9 +2,10 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import Cog
 
-from moosebot import MooseBot
+from moosebot import MooseBot, cog_group
 
 
+@cog_group("Info")
 class Server(Cog):
 
     def __init__(self, bot: MooseBot):

--- a/moosebot/cogs/shop.py
+++ b/moosebot/cogs/shop.py
@@ -5,9 +5,10 @@ import pymongo
 from discord.ext import commands
 from discord.ext.commands import Cog
 
-from moosebot import MooseBot
+from moosebot import MooseBot, cog_group
 
 
+@cog_group("Economy")
 class Shop(Cog):
 
     def __init__(self, bot: MooseBot):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ async-timeout==3.0.1
 attrs==19.1.0
 cffi==1.12.3
 chardet==3.0.4
-discord.py==1.1.1
+discord.py==1.2.3
 idna==2.8
 idna-ssl==1.1.0
 multidict==4.5.2
@@ -18,3 +18,5 @@ motor==2.0.0
 googletrans==2.4.0
 praw==6.2.0
 youtube_dl==2019.5.20
+pytz==2019.2
+geonamescache==1.0.3


### PR DESCRIPTION
 Add "automatic" help command that generates the embed from loaded cogs.

 - Added @cog_group decorator that can change the displayed cog name
   in the help command (this is located in cog_helper.py).
 - Updated discord.py version and added pytz and geonamescache to the
   requirements.txt.
 - Strip whitespace from token when it is read.
 - Add ignorable cogs in help command; currently: Voice/Experience
 - Set GuessGame cog name to "Guessing Game"
 - Set eight_ball command name to 8ball
 - Add cog group names to certain cogs:
   - Shop, Fishing are displayed in Economy
   - Counting, GuessGame, Phone are displayed in Interactive
   - Server is displayed in Info
   - Numbers is displayed in Misc
   - Colour is displayed in Fun
